### PR TITLE
Fix: Resolve ImportError due to relative imports

### DIFF
--- a/src/md_to_pdf.py
+++ b/src/md_to_pdf.py
@@ -18,7 +18,7 @@ from PIL import Image as PILImage
 import re
 import multiprocessing
 import psutil
-from .styling import get_all_styles, get_page_layout # Updated import
+from styling import get_all_styles, get_page_layout # Updated import
 from reportlab.platypus import Frame, PageTemplate # Added for existing code
 from reportlab.lib import colors # Added for add_border (though not directly used by create_pdf_with_reportlab styling)
 

--- a/src/styling.py
+++ b/src/styling.py
@@ -5,7 +5,7 @@ from reportlab.lib.enums import TA_LEFT
 from reportlab.lib import colors
 from reportlab.lib.units import inch
 import os
-from .utils import resource_path # Import resource_path
+from utils import resource_path # Import resource_path
 
 # Font Registration
 # Use resource_path to get the path to TimesNewRoman.ttf


### PR DESCRIPTION
I changed relative imports in `src/md_to_pdf.py` and `src/styling.py` to absolute imports.

This addresses the `ImportError: attempted relative import with no known parent package` that occurred when you ran `src/main.py` directly. The scripts are executed in the context of the `src` directory, allowing absolute imports from `src`.

- In `src/md_to_pdf.py`:
  - I changed `from .styling import ...` to `from styling import ...`
- In `src/styling.py`:
  - I changed `from .utils import ...` to `from utils import ...`